### PR TITLE
Fix GitHub Actions errors

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -111,7 +111,7 @@ jobs:
         
     # Upload DMG as artifact
     - name: Upload DMG artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Openterface-dmg
         path: build/*.dmg

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -57,7 +57,7 @@ jobs:
     # Build the macOS app using xcodebuild
     - name: Build macOS App
       env:
-        DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
         CODE_SIGN_IDENTITY: ${{ vars.CODE_SIGN_IDENTITY || 'Developer ID Application' }}
         DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM || 'NXWD68TXUQ' }}
         CI_EXPORT_OPTIONS_PLIST: 'ciExportOptions.plist'

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -60,6 +60,7 @@ jobs:
         DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
         CODE_SIGN_IDENTITY: ${{ vars.CODE_SIGN_IDENTITY || 'Developer ID Application' }}
         DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM || 'NXWD68TXUQ' }}
+        CI_EXPORT_OPTIONS_PLIST: 'ciExportOptions.plist'
       run: |
         xcodebuild -scheme "openterface" \
           -configuration Release \
@@ -68,11 +69,34 @@ jobs:
           CODE_SIGN_IDENTITY="$CODE_SIGN_IDENTITY" \
           CODE_SIGN_STYLE="Manual" \
           DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM"
-        
+
+        # Create a new export options plist with values from GitHub Action variables since
+        # these parameters cannot be overwritten in the command line
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > "$CI_EXPORT_OPTIONS_PLIST"
+        echo "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "<plist version=\"1.0\">" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "<dict>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <key>method</key>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <string>developer-id</string>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <key>teamID</key>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <string>$DEVELOPMENT_TEAM</string>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <key>signingStyle</key>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <string>manual</string>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <key>signingCertificate</key>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "    <string>$CODE_SIGN_IDENTITY</string>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "</dict>" >> "$CI_EXPORT_OPTIONS_PLIST"
+        echo "</plist>" >> "$CI_EXPORT_OPTIONS_PLIST"
+
+        echo "--- Export options for CI ---"
+        cat "$CI_EXPORT_OPTIONS_PLIST"
+        echo "-----------------------------"
+
+        # Use the export options plist created above as the export options
+        # Leaves the original one in the repository untouched
         xcodebuild -exportArchive \
           -archivePath "build/Openterface.xcarchive" \
           -exportPath "build/export" \
-          -exportOptionsPlist exportOptions.plist
+          -exportOptionsPlist "$CI_EXPORT_OPTIONS_PLIST"
 
     # Notarize the app
     - name: Notarize App

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -58,14 +58,16 @@ jobs:
     - name: Build macOS App
       env:
         DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+        CODE_SIGN_IDENTITY: ${{ vars.CODE_SIGN_IDENTITY || 'Developer ID Application' }}
+        DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM || 'NXWD68TXUQ' }}
       run: |
         xcodebuild -scheme "openterface" \
           -configuration Release \
           -archivePath "build/Openterface.xcarchive" \
           archive \
-          CODE_SIGN_IDENTITY="Developer ID Application" \
+          CODE_SIGN_IDENTITY="$CODE_SIGN_IDENTITY" \
           CODE_SIGN_STYLE="Manual" \
-          DEVELOPMENT_TEAM="NXWD68TXUQ"
+          DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM"
         
         xcodebuild -exportArchive \
           -archivePath "build/Openterface.xcarchive" \

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -100,15 +100,18 @@ jobs:
 
     # Notarize the app
     - name: Notarize App
+      # main branch only
+      if: github.ref == 'refs/heads/master'
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        DEVELOPMENT_TEAM: ${{ vars.DEVELOPMENT_TEAM || 'NXWD68TXUQ' }}
       run: |
         # Create temporary keychain
         xcrun notarytool store-credentials "notarytool-profile" \
           --apple-id "$APPLE_ID" \
           --password "$APPLE_APP_SPECIFIC_PASSWORD" \
-          --team-id "NXWD68TXUQ"
+          --team-id "$DEVELOPMENT_TEAM"
         
         # Submit app for notarization
         xcrun notarytool submit "build/export/Openterface.app" \


### PR DESCRIPTION
Hi,

I would like to make a contribution and fix your GitHub Actions. This PR makes the following changes:

1. Upgrades the `upload-artifact` Action to a newer version since the previous one has now been decommissioned by GitHub.
2. Parameterizes `CODE_SIGN_IDENTITY` and `DEVELOPMENT_TEAM` with GitHub Action variables so that another developer can run these actions when forking the repository using their own certificate.
3. Parameterizes `xcodebuild -exportArchive` to use the same variables. At this point, it creates a new export options plist file since there is no simple way to override the original plist contents on the command line.
4. Configures the notarization step to run only when the build runs against the `main` branch. Another developer on a fork may not have the required Apple Account.
5. Uses the latest version of XCode available on the hosted GitHub agent. The default version was causing a Segmentation Fault error on the `xcodebuild -exportArchive` step.

Cheers.