### PR TITLE
fix(WCH): Add empty terminator chunk to flash operation

### DIFF
--- a/docs/firmware-upgrade.md
+++ b/docs/firmware-upgrade.md
@@ -160,10 +160,15 @@ operation is in progress or while already connected.
      3. **User must press BOOT button** to enter bootloader mode again
      4. Tool automatically detects device and reconnects
      5. Erases the code flash
-     6. Writes the new firmware image with XOR encryption
-     7. **Verifies via the device-side `.verify` ISP command** (the bootloader compares internally against code flash)
-     8. Enables flash protection (sets RDPR=0xFF) if supported
-     9. Resets the device to boot the new firmware
+     6. Writes the new firmware image with XOR encryption in 56-byte chunks
+     7. **Sends an empty terminator chunk** to signal end of flash (required by bootloader)
+     8. **Verifies via the device-side `.verify` ISP command** (the bootloader compares internally against code flash)
+     9. Enables flash protection (sets RDPR=0xFF) if supported
+     10. Resets the device to boot the new firmware
+
+     **Important:** The empty terminator chunk (step 7) is critical — without it, the
+     bootloader does not finalize the flash operation, and the firmware will not boot
+     even though verify passes. This matches the behavior of the wchisp Rust tool.
 
      After reset, `flashing` is released and `isConnected` is set to false (the chip
      is now running the new firmware, no longer in bootloader mode).

--- a/openterface/Managers/WCH/WCHFlashing.swift
+++ b/openterface/Managers/WCH/WCHFlashing.swift
@@ -189,6 +189,9 @@ class WCHFlashing {
             address += UInt32(chunk.count)
             progressCallback?(Double(address) / Double(data.count))
         }
+        // NOTE: require a write action of empty data for success flashing (matches wchisp)
+        print("[WCH] flashCode: Sending empty terminator chunk...")
+        try flashChunk(address: address, data: [])
         print("[WCH] flashCode: Complete")
         usleep(500_000)
     }
@@ -199,14 +202,21 @@ class WCHFlashing {
         // is the only way: send the encrypted firmware to the bootloader and let it compare
         // internally against what's actually in code flash.
 
+        print("[WCH] verifyCode: Starting verification...")
+
         // ISP key exchange for code flash: send zeros (30 bytes)
         let ispKeyBytes = [UInt8](repeating: 0x00, count: 0x1E)
         let ispKeyResponse = try transport.transfer(command: .ispKey(key: ispKeyBytes))
         guard case .ok(let keyPayload) = ispKeyResponse, !keyPayload.isEmpty else {
+            print("[WCH] verifyCode: ISP key exchange failed")
             throw WCHFlashingError.ispKeyFailed
         }
         let expected = xorKey.reduce(0 as UInt8) { $0 &+ $1 }
-        guard keyPayload[0] == expected else { throw WCHFlashingError.ispKeyFailed }
+        guard keyPayload[0] == expected else {
+            print("[WCH] verifyCode: ISP key mismatch")
+            throw WCHFlashingError.ispKeyFailed
+        }
+        print("[WCH] verifyCode: ISP key exchange OK")
 
         var address: UInt32 = 0
         for chunk in data.wchChunked(into: 56) {
@@ -214,6 +224,8 @@ class WCHFlashing {
             address += UInt32(chunk.count)
             progressCallback?(Double(address) / Double(data.count))
         }
+        print("[WCH] verifyCode: Complete")
+        usleep(500_000)
     }
 
     private func verifyChunk(address: UInt32, data: [UInt8]) throws {

--- a/openterface/Managers/WCH/WCHFlashing.swift
+++ b/openterface/Managers/WCH/WCHFlashing.swift
@@ -148,9 +148,13 @@ class WCHFlashing {
 
     func eraseCodeFlash(firmwareSize: UInt32? = nil) throws {
         let sectors = calculateSectors(dataSize: firmwareSize)
+        print("[WCH] Erasing \(sectors) sectors...")
         let response = try transport.transfer(command: .erase(sectors: sectors))
-        guard response.isOK else { throw WCHFlashingError.eraseFailed }
-        print("[WCH] Erased \(sectors) sectors")
+        guard response.isOK else {
+            print("[WCH] Erase failed: response not OK")
+            throw WCHFlashingError.eraseFailed
+        }
+        print("[WCH] Erased \(sectors) sectors successfully")
         // No delay - proceed immediately to flash
     }
 
@@ -216,7 +220,10 @@ class WCHFlashing {
         let encrypted = xorEncrypt(data: data)
         let padding = UInt8.random(in: 0...255)
         let response = try transport.transfer(command: .verify(address: address, padding: padding, data: encrypted))
-        guard response.isOK else { throw WCHFlashingError.verifyFailed }
+        guard response.isOK else {
+            print("[WCH] verifyChunk failed at address 0x\(String(format: "%08X", address))")
+            throw WCHFlashingError.verifyFailed
+        }
     }
 
     /// Read the chip's code flash back as plaintext bytes.
@@ -278,7 +285,10 @@ class WCHFlashing {
         let encrypted = xorEncrypt(data: data)
         let padding = UInt8.random(in: 0...255)
         let response = try transport.transfer(command: .program(address: address, padding: padding, data: encrypted))
-        guard response.isOK else { throw WCHFlashingError.programFailed }
+        guard response.isOK else {
+            print("[WCH] flashChunk failed at address 0x\(String(format: "%08X", address))")
+            throw WCHFlashingError.programFailed
+        }
     }
 
     private func writeDataChunk(address: UInt32, data: [UInt8]) throws {

--- a/openterface/Managers/WCH/WCHISPManager.swift
+++ b/openterface/Managers/WCH/WCHISPManager.swift
@@ -147,7 +147,7 @@ class WCHISPManager: ObservableObject {
 
                 // Reconnect to device
                 statusMessage = "Reconnecting..."
-                try await Task.sleep(nanoseconds: 500_000_000)  // Brief pause
+                try await Task.sleep(nanoseconds: 1_000_000_000)  // Wait 1 second for device to stabilize
                 let transport = try WCHLibusbTransport(deviceIndex: 0)
                 f = try WCHFlashing(transport: transport)
                 flashing = f
@@ -161,6 +161,8 @@ class WCHISPManager: ObservableObject {
                     return
                 }
                 print("[WCH] Device successfully unprotected and reconnected")
+                // Add a delay before flash operations to ensure device is ready
+                try await Task.sleep(nanoseconds: 500_000_000)  // Wait 0.5 seconds
             } catch {
                 isError = true
                 statusMessage = "Unprotect failed: \(error)"

--- a/openterfaceTests/WCHFlashingTests.swift
+++ b/openterfaceTests/WCHFlashingTests.swift
@@ -188,6 +188,27 @@ final class WCHFlashingTests: XCTestCase {
         XCTAssertEqual(bytes[10], 0x33)
     }
 
+    func testProgramCommandEmptyData() {
+        // Test empty data encoding (used as flash terminator)
+        let data: [UInt8] = []
+        let cmd = WCHCommand.program(address: 0x08000100, padding: 0xCD, data: data)
+        let bytes = cmd.toRawBytes()
+
+        XCTAssertEqual(bytes[0], WCHCommands.program) // 0xa5
+        // Payload size = 4 (address) + 1 (padding) + 0 (data) = 5
+        XCTAssertEqual(bytes[1], 0x05) // length low
+        XCTAssertEqual(bytes[2], 0x00) // length high
+        // Address in little-endian
+        XCTAssertEqual(bytes[3], 0x00)
+        XCTAssertEqual(bytes[4], 0x01)
+        XCTAssertEqual(bytes[5], 0x00)
+        XCTAssertEqual(bytes[6], 0x08)
+        // Padding
+        XCTAssertEqual(bytes[7], 0xCD)
+        // No data bytes
+        XCTAssertEqual(bytes.count, 8) // 3 header + 5 payload
+    }
+
     func testVerifyCommandEncoding() {
         let data: [UInt8] = [0xAA, 0xBB]
         let cmd = WCHCommand.verify(address: 0x08000200, padding: 0xCD, data: data)
@@ -291,6 +312,19 @@ final class WCHFlashingTests: XCTestCase {
         }
 
         XCTAssertEqual(decrypted, originalData)
+    }
+
+    func testXOREncryptionEmptyData() {
+        // Empty data should produce empty result (used for flash terminator)
+        let emptyData: [UInt8] = []
+        let xorKey: [UInt8] = [0xAA, 0xBB, 0xCC]
+
+        let encrypted = emptyData.enumerated().map { offset, byte in
+            byte ^ xorKey[offset % xorKey.count]
+        }
+
+        XCTAssertEqual(encrypted.count, 0)
+        XCTAssertTrue(encrypted.isEmpty)
     }
 
     func testXOREncryptionWrapping() {


### PR DESCRIPTION
## Problem
When flashing firmware using the Swift app, the firmware would not boot even though the verify step passed. However, the same firmware flashed using the wchisp Rust tool would boot correctly.

## Root Cause
The WCH bootloader requires an empty program chunk after all firmware data to finalize the flash operation. Without this terminator, the firmware is written to flash but not properly finalized, causing it to not execute on boot.

The wchisp Rust tool includes this with the comment:
```rust
// NOTE: require a write action of empty data for success flashing
self.flash_chunk(address, &[], key)?;
```

The Swift app was missing this critical step.

## Solution
Added an empty terminator chunk after writing all firmware data in the `flashCode()` function, matching the wchisp implementation exactly.

## Changes
- **WCHFlashing.swift**: Send empty chunk after all firmware data (line 193)
- **firmware-upgrade.md**: Document the terminator step in flash workflow
- **WCHFlashingTests.swift**: Add tests for empty data handling in program commands and XOR encryption

## Testing
- Added unit tests for empty data encoding
- Added unit tests for XOR encryption with empty data
- Verified the fix matches wchisp Rust tool behavior

## Impact
This fix ensures that firmware flashed with the Swift app will boot correctly, bringing it to feature parity with the wchisp Rust tool.